### PR TITLE
我已经在用这个框架了，开发过程中碰到的问题我修改了下，看你那边有无必要合并

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # MVVMSmart-kotlin
 > 目前，android基于MVVM模式开发框架比较少。**MVVMSmart-kotlin是以谷歌Jetpack架构组件ViewModel+Lifecycles+Navigation+DataBinding+LiveData+Okhttp+Retrofit+RxJava+Glide等，加上各种原生控件自定义的BindingAdapter，让事件与数据源完美绑定的一款容易上瘾的实用性MVVM快速开发框架**。告别findViewById()，告别setText()，告别setOnClickListener()...
 ## 技术讨QQ群：531944409
+## 最新日志 **v2.0：2020年7月3日**
+1. 引入[RetrofitUrlManager](https://github.com/JessYanCoding/RetrofitUrlManager),以最简洁的 Api 让 Retrofit 同时支持多个 BaseUrl 以及动态改变 BaseUrl
+2. 增加Gson解析 BooleanTypeAdapter，StringTypeAdapter的处理，服务器返回的boolean可能为1和null，避免解析错误
 ## 最新日志 **v2.0：2020年6月9日**
 1. 重构优化网络框架
 2. 全局的Loading封装,loading包含动画功能,rxjava封装调用

--- a/app/src/main/java/com/wzq/sample/bean/BaseUrlData.kt
+++ b/app/src/main/java/com/wzq/sample/bean/BaseUrlData.kt
@@ -1,0 +1,7 @@
+package com.wzq.sample.bean
+
+class BaseUrlData {
+    var code:Int=0
+    var message:String=""
+    var result:String=""
+}

--- a/app/src/main/java/com/wzq/sample/bean/TestGson.kt
+++ b/app/src/main/java/com/wzq/sample/bean/TestGson.kt
@@ -1,0 +1,22 @@
+package com.wzq.sample.bean
+
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * @hloong 测试GSON解析
+ */
+data class TestGson(
+    @SerializedName("error")
+    var error: String = "",
+    @SerializedName("message")
+    var message: Long =0,
+    @SerializedName("status")
+    var status: Int = 0,
+    @SerializedName("success")
+    var success: Boolean = false,
+    @SerializedName("timestamp")
+    var timestamp:Double=0.0,
+    @SerializedName("type")
+    var type: Float = 0f
+)

--- a/app/src/main/java/com/wzq/sample/net/DemoApiService.kt
+++ b/app/src/main/java/com/wzq/sample/net/DemoApiService.kt
@@ -4,12 +4,9 @@ import com.wzq.mvvmsmart.net.base.BaseResponse
 import com.wzq.sample.bean.DemoBean
 import com.wzq.sample.bean.NewsData
 import io.reactivex.Observable
+import me.jessyan.retrofiturlmanager.RetrofitUrlManager
 import okhttp3.RequestBody
-import retrofit2.http.Body
-import retrofit2.http.GET
-import retrofit2.http.POST
-import retrofit2.http.Path
-import retrofit2.http.Query
+import retrofit2.http.*
 
 /**
  * created 王志强 2020.04.30
@@ -25,5 +22,13 @@ interface DemoApiService {
     //  获取网络数据
     @POST("AppNews/getNewsList/type/1/p/1")
     fun doPostServerNews(@Body requestBody: RequestBody): Observable<BaseResponse<ArrayList<NewsData>>>
+    //  获取网络数据
+    @POST("AppNews/getNewsList/type/1/p/1")
+    fun doPostServerNewsCustom(@Body requestBody: RequestBody): Observable<String>
+
+    //只针对单接口动态替换retrofit的BaseUrl，更多高级用法请参考https://github.com/JessYanCoding/RetrofitUrlManager
+    @Headers(RetrofitUrlManager.DOMAIN_NAME_HEADER+"api")
+    @GET("/singlePoetry")
+    fun doBaseUrl(): Observable<String>
 
 }

--- a/app/src/main/java/com/wzq/sample/net/DemoApiService.kt
+++ b/app/src/main/java/com/wzq/sample/net/DemoApiService.kt
@@ -1,6 +1,7 @@
 package com.wzq.sample.net
 
 import com.wzq.mvvmsmart.net.base.BaseResponse
+import com.wzq.sample.bean.BaseUrlData
 import com.wzq.sample.bean.DemoBean
 import com.wzq.sample.bean.NewsData
 import io.reactivex.Observable
@@ -22,13 +23,10 @@ interface DemoApiService {
     //  获取网络数据
     @POST("AppNews/getNewsList/type/1/p/1")
     fun doPostServerNews(@Body requestBody: RequestBody): Observable<BaseResponse<ArrayList<NewsData>>>
-    //  获取网络数据
-    @POST("AppNews/getNewsList/type/1/p/1")
-    fun doPostServerNewsCustom(@Body requestBody: RequestBody): Observable<String>
 
     //只针对单接口动态替换retrofit的BaseUrl，更多高级用法请参考https://github.com/JessYanCoding/RetrofitUrlManager
     @Headers(RetrofitUrlManager.DOMAIN_NAME_HEADER+"api")
     @GET("/singlePoetry")
-    fun doBaseUrl(): Observable<String>
+    fun doBaseUrl(): Observable<BaseUrlData>
 
 }

--- a/app/src/main/java/com/wzq/sample/net/MRequest.java
+++ b/app/src/main/java/com/wzq/sample/net/MRequest.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import com.wzq.mvvmsmart.net.base.BaseRequest;
 import com.wzq.mvvmsmart.net.base.BaseResponse;
 import com.wzq.mvvmsmart.utils.constant.NetConstants;
+import com.wzq.sample.bean.BaseUrlData;
 import com.wzq.sample.bean.DemoBean;
 import com.wzq.sample.bean.NewsData;
 import io.reactivex.Observable;
@@ -52,14 +53,10 @@ public class MRequest extends BaseRequest {
         Observable<BaseResponse<ArrayList<NewsData>>> observable = service.doPostServerNews(requestBody);
         return observable;
     }
-    // post请求 返回字符串数据由用户自己解析，特定场景使用
-    public Observable<String> doPostServerNewsCustom(String jsonParams) {
-        RequestBody requestBody = RequestBody.create(MediaType.parse(NetConstants.APPLICATION_JSON), jsonParams);
-        Observable<String> observable = service.doPostServerNewsCustom(requestBody);
-        return observable;
-    }
+
+
     // 动态设置baseUrl，针对baseUrl从配置文件配置的场景
-    public Observable<String> doBaseUrl() {
+    public Observable<BaseUrlData> doBaseUrl() {
         return service.doBaseUrl();
     }
 }

--- a/app/src/main/java/com/wzq/sample/net/MRequest.java
+++ b/app/src/main/java/com/wzq/sample/net/MRequest.java
@@ -52,5 +52,14 @@ public class MRequest extends BaseRequest {
         Observable<BaseResponse<ArrayList<NewsData>>> observable = service.doPostServerNews(requestBody);
         return observable;
     }
-
+    // post请求 返回字符串数据由用户自己解析，特定场景使用
+    public Observable<String> doPostServerNewsCustom(String jsonParams) {
+        RequestBody requestBody = RequestBody.create(MediaType.parse(NetConstants.APPLICATION_JSON), jsonParams);
+        Observable<String> observable = service.doPostServerNewsCustom(requestBody);
+        return observable;
+    }
+    // 动态设置baseUrl，针对baseUrl从配置文件配置的场景
+    public Observable<String> doBaseUrl() {
+        return service.doBaseUrl();
+    }
 }

--- a/app/src/main/java/com/wzq/sample/net/MRequest.java
+++ b/app/src/main/java/com/wzq/sample/net/MRequest.java
@@ -3,6 +3,7 @@ package com.wzq.sample.net;
 import android.annotation.SuppressLint;
 import com.wzq.mvvmsmart.net.base.BaseRequest;
 import com.wzq.mvvmsmart.net.base.BaseResponse;
+import com.wzq.mvvmsmart.utils.constant.NetConstants;
 import com.wzq.sample.bean.DemoBean;
 import com.wzq.sample.bean.NewsData;
 import io.reactivex.Observable;
@@ -45,9 +46,9 @@ public class MRequest extends BaseRequest {
         return observable;
     }
 
-    // post请求
+    // post请求 JSON
     public Observable<BaseResponse<ArrayList<NewsData>>> doPostServerNews(String jsonParams) {
-        RequestBody requestBody = RequestBody.create(MediaType.parse("application/json; charset=utf-8"), jsonParams);
+        RequestBody requestBody = RequestBody.create(MediaType.parse(NetConstants.APPLICATION_JSON), jsonParams);
         Observable<BaseResponse<ArrayList<NewsData>>> observable = service.doPostServerNews(requestBody);
         return observable;
     }

--- a/app/src/main/java/com/wzq/sample/ui/MainActivity.kt
+++ b/app/src/main/java/com/wzq/sample/ui/MainActivity.kt
@@ -3,10 +3,14 @@ package com.wzq.sample.ui
 import android.annotation.SuppressLint
 import android.content.pm.ActivityInfo
 import android.os.Bundle
+import com.google.gson.reflect.TypeToken
+import com.wzq.mvvmsmart.net.net_utils.GsonUtil
+import com.wzq.mvvmsmart.utils.KLog
 import com.wzq.sample.BR
 import com.wzq.sample.R
 import com.wzq.sample.base.BaseActivity
 import com.wzq.sample.base.BaseViewModel
+import com.wzq.sample.bean.TestGson
 import com.wzq.sample.databinding.ActivityDemoBinding
 
 class MainActivity : BaseActivity<ActivityDemoBinding, BaseViewModel>() {
@@ -18,7 +22,25 @@ class MainActivity : BaseActivity<ActivityDemoBinding, BaseViewModel>() {
         requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
     }
 
-
+    override fun initData() {
+        //测试Gson Utils的解析,替换boolean的null和string的null
+        // 测试当boolean返回0动态替换false，1动态替换true，返回null替换false
+        var json  = "{\n" +
+                "\t\"status\": 0.0,\n" +
+                "\t\"message\": null,\n" +
+                "\t\"error\": null,\n" +
+                "\t\"type\": \"1\",\n" +
+                "\t\"success\": null,\n" +
+                "\t\"timestamp\": \"0\"\n" +
+                "}"
+        val data = GsonUtil.gson2Bean(json,TestGson::class.java)
+        KLog.d("status==="+data.status+
+                "===error==="+data.error+
+                "===message===" +data.message+
+                "===success==="+data.success+
+                "===timestamp==="+data.timestamp+
+                "===type==="+data.type)
+    }
 
     override fun initContentView(savedInstanceState: Bundle?): Int {
         return R.layout.activity_demo

--- a/app/src/main/java/com/wzq/sample/ui/testnet/TestNetFragment.kt
+++ b/app/src/main/java/com/wzq/sample/ui/testnet/TestNetFragment.kt
@@ -5,11 +5,18 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.lifecycle.Observer
+import com.google.gson.reflect.TypeToken
+import com.wzq.mvvmsmart.net.base.BaseResponse
+import com.wzq.mvvmsmart.net.net_utils.GsonUtil
 import com.wzq.mvvmsmart.utils.KLog
 import com.wzq.sample.BR
 import com.wzq.sample.R
 import com.wzq.sample.base.BaseFragment
+import com.wzq.sample.bean.BaseUrlData
+import com.wzq.sample.bean.NewsData
 import com.wzq.sample.databinding.FragmentTestNetBinding
+import me.jessyan.retrofiturlmanager.RetrofitUrlManager
+import java.lang.Exception
 
 /**
  * Create Date：2019/01/25
@@ -35,5 +42,41 @@ class TestNetFragment : BaseFragment<FragmentTestNetBinding, TestNetViewModel>()
                 binding.tvJson.text = it[0].news_summary
             }
         })
+
+        binding.buttonCustom.setOnClickListener {
+            //此处请求 返回结果需要用户自己解析
+            viewModel.doPostServerNewsCustom()
+        }
+        viewModel.liveDataString.observe(this, Observer {
+            try {
+                KLog.d(it)
+                val data = GsonUtil.getGson().fromJson<BaseResponse<ArrayList<NewsData>>>(it,
+                        object : TypeToken<BaseResponse<ArrayList<NewsData>>>(){}.type)
+                if (data != null && data.data.isNotEmpty()){
+                    binding.tvJson.text = data.data[0].news_summary
+                }
+            }catch (e:Exception){
+                e.printStackTrace()
+            }
+        })
+
+        binding.buttonBaseUrl.setOnClickListener {
+            //只针对该接口动态使用https://api.apiopen.top
+            RetrofitUrlManager.getInstance().putDomain("api","https://api.apiopen.top")
+            viewModel.doBaseUrl()
+        }
+        viewModel.liveDataBaseUrl.observe(this, Observer {
+            try {
+                KLog.d(it)
+                val data = GsonUtil.getGson().fromJson<BaseUrlData>(it,
+                        object : TypeToken<BaseUrlData>(){}.type)
+                if (data != null){
+                    binding.tvJson.text = data.message+"--"+data.code
+                }
+            }catch (e:Exception){
+                e.printStackTrace()
+            }
+        })
+
     }
 }

--- a/app/src/main/java/com/wzq/sample/ui/testnet/TestNetFragment.kt
+++ b/app/src/main/java/com/wzq/sample/ui/testnet/TestNetFragment.kt
@@ -43,35 +43,17 @@ class TestNetFragment : BaseFragment<FragmentTestNetBinding, TestNetViewModel>()
             }
         })
 
-        binding.buttonCustom.setOnClickListener {
-            //此处请求 返回结果需要用户自己解析
-            viewModel.doPostServerNewsCustom()
-        }
-        viewModel.liveDataString.observe(this, Observer {
-            try {
-                KLog.d(it)
-                val data = GsonUtil.getGson().fromJson<BaseResponse<ArrayList<NewsData>>>(it,
-                        object : TypeToken<BaseResponse<ArrayList<NewsData>>>(){}.type)
-                if (data != null && data.data.isNotEmpty()){
-                    binding.tvJson.text = data.data[0].news_summary
-                }
-            }catch (e:Exception){
-                e.printStackTrace()
-            }
-        })
 
         binding.buttonBaseUrl.setOnClickListener {
-            //只针对该接口动态使用https://api.apiopen.top
+            //只针对该接口动态使用https://api.apiopen.top，其他接口依旧采用全局BaseUrl，更多用法参考 https://github.com/JessYanCoding/RetrofitUrlManager
             RetrofitUrlManager.getInstance().putDomain("api","https://api.apiopen.top")
             viewModel.doBaseUrl()
         }
         viewModel.liveDataBaseUrl.observe(this, Observer {
             try {
                 KLog.d(it)
-                val data = GsonUtil.getGson().fromJson<BaseUrlData>(it,
-                        object : TypeToken<BaseUrlData>(){}.type)
-                if (data != null){
-                    binding.tvJson.text = data.message+"--"+data.code
+                if (it != null){
+                    binding.tvJson.text = it.message+"--"+it.code
                 }
             }catch (e:Exception){
                 e.printStackTrace()

--- a/app/src/main/java/com/wzq/sample/ui/testnet/TestNetViewModel.kt
+++ b/app/src/main/java/com/wzq/sample/ui/testnet/TestNetViewModel.kt
@@ -10,6 +10,7 @@ import com.wzq.mvvmsmart.net.net_utils.GsonUtil
 import com.wzq.mvvmsmart.net.observer.DefaultObserver
 import com.wzq.mvvmsmart.net.net_utils.RxUtil
 import com.wzq.sample.bean.NewsData
+import io.reactivex.Observer
 import io.reactivex.disposables.Disposable
 import java.util.*
 
@@ -21,6 +22,8 @@ import java.util.*
 class TestNetViewModel(application: Application) : BaseViewModel(application) {
     //给RecyclerView添加ObservableList
     var liveData = MutableLiveData<List<NewsData>>()
+    var liveDataString = MutableLiveData<String>()
+    var liveDataBaseUrl = MutableLiveData<String>()
 
     /**
     线程调度,compose操作符是直接对当前Observable进行操作（可简单理解为不停地.方法名（）.方法名（）链式操作当前Observable）
@@ -75,6 +78,51 @@ class TestNetViewModel(application: Application) : BaseViewModel(application) {
                         //关闭对话框
                     }
 
+                })
+
+    }
+    fun doPostServerNewsCustom() {
+//        val param: Map<String, String> = HashMap()
+        // 这里的参数是随便模拟的
+        val param = mapOf("key" to 24,"name" to "zhangsan","age" to 25)
+        val observable = MRequest.getInstance().doPostServerNewsCustom(GsonUtil.bean2String(param))
+        observable.compose(RxUtil.observableToMain()) //线程调度,compose操作符是直接对当前Observable进行操作（可简单理解为不停地.方法名（）.方法名（）链式操作当前Observable）
+                .compose(RxUtil.exceptionTransformer()) // 网络错误的异常转换, 这里可以换成自己的ExceptionHandle
+                .doOnSubscribe(this@TestNetViewModel) //  请求与ViewModel周期同步
+                .subscribe(object :Observer<String>{
+                    override fun onNext(t: String) {
+                        KLog.d(t)
+                        liveDataString.postValue(t)
+                    }
+                    override fun onComplete() {
+                    }
+
+                    override fun onSubscribe(d: Disposable) {
+                    }
+
+                    override fun onError(e: Throwable) {
+                    }
+                })
+
+    }
+    fun doBaseUrl() {
+        val observable = MRequest.getInstance().doBaseUrl()
+        observable.compose(RxUtil.observableToMain()) //线程调度,compose操作符是直接对当前Observable进行操作（可简单理解为不停地.方法名（）.方法名（）链式操作当前Observable）
+                .compose(RxUtil.exceptionTransformer()) // 网络错误的异常转换, 这里可以换成自己的ExceptionHandle
+                .doOnSubscribe(this@TestNetViewModel) //  请求与ViewModel周期同步
+                .subscribe(object :Observer<String>{
+                    override fun onNext(t: String) {
+                        KLog.d(t)
+                        liveDataBaseUrl.postValue(t)
+                    }
+                    override fun onComplete() {
+                    }
+
+                    override fun onSubscribe(d: Disposable) {
+                    }
+
+                    override fun onError(e: Throwable) {
+                    }
                 })
 
     }

--- a/app/src/main/java/com/wzq/sample/ui/testnet/TestNetViewModel.kt
+++ b/app/src/main/java/com/wzq/sample/ui/testnet/TestNetViewModel.kt
@@ -9,6 +9,7 @@ import com.wzq.mvvmsmart.net.base.BaseResponse
 import com.wzq.mvvmsmart.net.net_utils.GsonUtil
 import com.wzq.mvvmsmart.net.observer.DefaultObserver
 import com.wzq.mvvmsmart.net.net_utils.RxUtil
+import com.wzq.sample.bean.BaseUrlData
 import com.wzq.sample.bean.NewsData
 import io.reactivex.Observer
 import io.reactivex.disposables.Disposable
@@ -21,9 +22,8 @@ import java.util.*
  */
 class TestNetViewModel(application: Application) : BaseViewModel(application) {
     //给RecyclerView添加ObservableList
-    var liveData = MutableLiveData<List<NewsData>>()
-    var liveDataString = MutableLiveData<String>()
-    var liveDataBaseUrl = MutableLiveData<String>()
+    var liveData = MutableLiveData<ArrayList<NewsData>>()
+    var liveDataBaseUrl = MutableLiveData<BaseUrlData>()
 
     /**
     线程调度,compose操作符是直接对当前Observable进行操作（可简单理解为不停地.方法名（）.方法名（）链式操作当前Observable）
@@ -81,37 +81,14 @@ class TestNetViewModel(application: Application) : BaseViewModel(application) {
                 })
 
     }
-    fun doPostServerNewsCustom() {
-//        val param: Map<String, String> = HashMap()
-        // 这里的参数是随便模拟的
-        val param = mapOf("key" to 24,"name" to "zhangsan","age" to 25)
-        val observable = MRequest.getInstance().doPostServerNewsCustom(GsonUtil.bean2String(param))
-        observable.compose(RxUtil.observableToMain()) //线程调度,compose操作符是直接对当前Observable进行操作（可简单理解为不停地.方法名（）.方法名（）链式操作当前Observable）
-                .compose(RxUtil.exceptionTransformer()) // 网络错误的异常转换, 这里可以换成自己的ExceptionHandle
-                .doOnSubscribe(this@TestNetViewModel) //  请求与ViewModel周期同步
-                .subscribe(object :Observer<String>{
-                    override fun onNext(t: String) {
-                        KLog.d(t)
-                        liveDataString.postValue(t)
-                    }
-                    override fun onComplete() {
-                    }
-
-                    override fun onSubscribe(d: Disposable) {
-                    }
-
-                    override fun onError(e: Throwable) {
-                    }
-                })
-
-    }
+    //跟上面用DefaultObserver不同，有些接口返回的数据不是通用的BaseResponse
     fun doBaseUrl() {
         val observable = MRequest.getInstance().doBaseUrl()
-        observable.compose(RxUtil.observableToMain()) //线程调度,compose操作符是直接对当前Observable进行操作（可简单理解为不停地.方法名（）.方法名（）链式操作当前Observable）
-                .compose(RxUtil.exceptionTransformer()) // 网络错误的异常转换, 这里可以换成自己的ExceptionHandle
-                .doOnSubscribe(this@TestNetViewModel) //  请求与ViewModel周期同步
-                .subscribe(object :Observer<String>{
-                    override fun onNext(t: String) {
+        observable.compose(RxUtil.observableToMain())
+                .compose(RxUtil.exceptionTransformer())
+                .doOnSubscribe(this@TestNetViewModel)
+                .subscribe(object :Observer<BaseUrlData>{
+                    override fun onNext(t: BaseUrlData) {
                         KLog.d(t)
                         liveDataBaseUrl.postValue(t)
                     }
@@ -122,8 +99,11 @@ class TestNetViewModel(application: Application) : BaseViewModel(application) {
                     }
 
                     override fun onError(e: Throwable) {
+                        KLog.d(e.printStackTrace())
                     }
                 })
 
     }
+
+
 }

--- a/app/src/main/res/layout/fragment_test_net.xml
+++ b/app/src/main/res/layout/fragment_test_net.xml
@@ -21,13 +21,28 @@
       android:layout_marginTop="20dp"
       android:text="请求接口" />
 
+    <Button
+        android:id="@+id/button_base_url"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="15dp"
+        android:layout_marginTop="20dp"
+        android:text="动态设置BaseURL请求接口" />
+
+    <Button
+        android:id="@+id/button_custom"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="15dp"
+        android:layout_marginTop="20dp"
+        android:text="请求接口非BaseResponse处理" />
     <TextView
-      android:id="@+id/tvJson"
-      android:layout_width="match_parent"
-      android:layout_marginHorizontal="15dp"
-      android:layout_height="wrap_content"
-      android:layout_marginTop="20dp"
-      android:lineSpacingExtra="5dp"
-      android:text="result: " />
+        android:id="@+id/tvJson"
+        android:layout_width="match_parent"
+        android:layout_marginHorizontal="15dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:lineSpacingExtra="5dp"
+        android:text="result: " />
   </LinearLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_test_net.xml
+++ b/app/src/main/res/layout/fragment_test_net.xml
@@ -29,13 +29,6 @@
         android:layout_marginTop="20dp"
         android:text="动态设置BaseURL请求接口" />
 
-    <Button
-        android:id="@+id/button_custom"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="15dp"
-        android:layout_marginTop="20dp"
-        android:text="请求接口非BaseResponse处理" />
     <TextView
         android:id="@+id/tvJson"
         android:layout_width="match_parent"

--- a/mvvmsmart/build.gradle
+++ b/mvvmsmart/build.gradle
@@ -75,6 +75,7 @@ dependencies {
     api "androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0"
     api "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     api rootProject.ext.dependencies["MMKV"]  //共享参数
+    api 'me.jessyan:retrofit-url-manager:1.4.0'// 多baseUrl替换 https://github.com/JessYanCoding/RetrofitUrlManager
 }
 repositories {
     mavenCentral()

--- a/mvvmsmart/src/main/java/com/wzq/mvvmsmart/net/net_utils/GsonUtil.java
+++ b/mvvmsmart/src/main/java/com/wzq/mvvmsmart/net/net_utils/GsonUtil.java
@@ -3,10 +3,12 @@ package com.wzq.mvvmsmart.net.net_utils;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
+import com.wzq.mvvmsmart.net.net_utils.gsontypeadapter.BooleanTypeAdapter;
 import com.wzq.mvvmsmart.net.net_utils.gsontypeadapter.IntegerTypeAdapter;
 import com.wzq.mvvmsmart.net.net_utils.gsontypeadapter.LongTypeAdapter;
 import com.wzq.mvvmsmart.net.net_utils.gsontypeadapter.DoubleTypeAdapter;
 import com.wzq.mvvmsmart.net.net_utils.gsontypeadapter.FloatTypeAdapter;
+import com.wzq.mvvmsmart.net.net_utils.gsontypeadapter.StringTypeAdapter;
 
 import java.util.List;
 import java.util.Map;
@@ -29,6 +31,9 @@ public class GsonUtil {
                     .registerTypeAdapter(long.class, new LongTypeAdapter())
                     .registerTypeAdapter(Float.class, new FloatTypeAdapter())
                     .registerTypeAdapter(float.class, new FloatTypeAdapter())
+                    .registerTypeAdapter(Boolean.class, new BooleanTypeAdapter())
+                    .registerTypeAdapter(boolean.class, new BooleanTypeAdapter())
+                    .registerTypeAdapter(String.class, new StringTypeAdapter())
                     .create();
         }
     }

--- a/mvvmsmart/src/main/java/com/wzq/mvvmsmart/net/net_utils/OkHttpUtil.java
+++ b/mvvmsmart/src/main/java/com/wzq/mvvmsmart/net/net_utils/OkHttpUtil.java
@@ -8,6 +8,7 @@ import com.wzq.mvvmsmart.net.cookie.MemoryCookieStore;
 
 import java.util.concurrent.TimeUnit;
 
+import me.jessyan.retrofiturlmanager.RetrofitUrlManager;
 import okhttp3.OkHttpClient;
 
 /**
@@ -35,7 +36,7 @@ public class OkHttpUtil {
      */
     OkHttpClient okHttpsCacheClient() {
         if (okHttpClient == null) {
-            okHttpClient = okHttpsBuilder().build();
+            okHttpClient = RetrofitUrlManager.getInstance().with(okHttpsBuilder()).build();
         }
         return okHttpClient;
     }

--- a/mvvmsmart/src/main/java/com/wzq/mvvmsmart/net/net_utils/gsontypeadapter/BooleanTypeAdapter.java
+++ b/mvvmsmart/src/main/java/com/wzq/mvvmsmart/net/net_utils/gsontypeadapter/BooleanTypeAdapter.java
@@ -42,7 +42,7 @@ public class BooleanTypeAdapter extends TypeAdapter<Boolean> {
             if (in.peek() == JsonToken.STRING) {
                 String str = in.nextString();
                 if (NumberUtils.isFloatOrDouble(str)){
-                    return Double.valueOf(str)== Double.valueOf(0) ? false:true;
+                    return Double.valueOf(str)== Double.valueOf(1) ? true:false;
                 } else {
                     Log.e("TypeAdapter", str + " is not a number");
                 }

--- a/mvvmsmart/src/main/java/com/wzq/mvvmsmart/net/net_utils/gsontypeadapter/BooleanTypeAdapter.java
+++ b/mvvmsmart/src/main/java/com/wzq/mvvmsmart/net/net_utils/gsontypeadapter/BooleanTypeAdapter.java
@@ -1,0 +1,57 @@
+package com.wzq.mvvmsmart.net.net_utils.gsontypeadapter;
+
+import android.util.Log;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+
+/**
+ * created 王志强 2020.04.30
+ * 部分服务器框架会把数字数据返回null, 并且服务器处理不好,客户端可以处理
+ */
+public class BooleanTypeAdapter extends TypeAdapter<Boolean> {
+    @Override
+    public void write(JsonWriter out, Boolean value) throws IOException {
+        try {
+            if (value == null){
+                value = false;
+            }
+            out.value(value);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public Boolean read(JsonReader in) throws IOException {
+        try {
+            if (in.peek() == JsonToken.NULL) {
+                in.nextNull();
+                Log.e("TypeAdapter", "null is not a boolean");
+                return false;
+            }
+            if (in.peek() == JsonToken.NUMBER) {
+                Double value = in.nextDouble();
+                Log.e("TypeAdapter", value+ " is not a boolean");
+                return value == Double.valueOf(0) ? false : true;
+            }
+            if (in.peek() == JsonToken.STRING) {
+                String str = in.nextString();
+                if (NumberUtils.isFloatOrDouble(str)){
+                    return Double.valueOf(str)== Double.valueOf(0) ? false:true;
+                } else {
+                    Log.e("TypeAdapter", str + " is not a number");
+                }
+            }
+        }catch(NumberFormatException e){
+            Log.e("TypeAdapter", e.getMessage(), e);
+        } catch (Exception e) {
+            Log.e("TypeAdapter", e.getMessage(), e);
+        }
+        return false;
+    }
+}

--- a/mvvmsmart/src/main/java/com/wzq/mvvmsmart/net/net_utils/gsontypeadapter/BooleanTypeAdapter.java
+++ b/mvvmsmart/src/main/java/com/wzq/mvvmsmart/net/net_utils/gsontypeadapter/BooleanTypeAdapter.java
@@ -10,7 +10,7 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 
 /**
- * created 王志强 2020.04.30
+ * created @hloong 2020.06.30
  * 部分服务器框架会把数字数据返回null, 并且服务器处理不好,客户端可以处理
  */
 public class BooleanTypeAdapter extends TypeAdapter<Boolean> {
@@ -37,7 +37,7 @@ public class BooleanTypeAdapter extends TypeAdapter<Boolean> {
             if (in.peek() == JsonToken.NUMBER) {
                 Double value = in.nextDouble();
                 Log.e("TypeAdapter", value+ " is not a boolean");
-                return value == Double.valueOf(0) ? false : true;
+                return value == Double.valueOf(1) ? true : false;//boolean 有时候服务器给的是1，表示true，0可能就是false
             }
             if (in.peek() == JsonToken.STRING) {
                 String str = in.nextString();

--- a/mvvmsmart/src/main/java/com/wzq/mvvmsmart/net/net_utils/gsontypeadapter/StringTypeAdapter.java
+++ b/mvvmsmart/src/main/java/com/wzq/mvvmsmart/net/net_utils/gsontypeadapter/StringTypeAdapter.java
@@ -1,0 +1,43 @@
+package com.wzq.mvvmsmart.net.net_utils.gsontypeadapter;
+
+import android.util.Log;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+
+/**
+ * created 王志强 2020.04.30
+ */
+public class StringTypeAdapter extends TypeAdapter<String> {
+
+
+    @Override
+    public void write(JsonWriter out, String value) throws IOException {
+        try {
+            if (value == null){
+                value = "";
+            }
+            out.value(value);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public String read(JsonReader in) throws IOException {
+        try {
+            if (in.peek() == JsonToken.NULL) {
+                in.nextNull();
+                Log.e("TypeAdapter", "null is not a string");
+                return "";
+            }
+        } catch (Exception e) {
+            Log.e("TypeAdapter", "Not a String", e);
+        }
+        return "";
+    }
+}

--- a/mvvmsmart/src/main/java/com/wzq/mvvmsmart/net/net_utils/gsontypeadapter/StringTypeAdapter.java
+++ b/mvvmsmart/src/main/java/com/wzq/mvvmsmart/net/net_utils/gsontypeadapter/StringTypeAdapter.java
@@ -10,7 +10,7 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 
 /**
- * created 王志强 2020.04.30
+ * created @hloong 2020.06.30
  */
 public class StringTypeAdapter extends TypeAdapter<String> {
 

--- a/mvvmsmart/src/main/java/com/wzq/mvvmsmart/net/observer/DefaultObserver.java
+++ b/mvvmsmart/src/main/java/com/wzq/mvvmsmart/net/observer/DefaultObserver.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.wzq.mvvmsmart.net.base.BaseObserver;
 import com.wzq.mvvmsmart.net.base.BaseResponse;
+import com.wzq.mvvmsmart.net.net_utils.GsonUtil;
 import com.wzq.mvvmsmart.utils.KLog;
 import io.reactivex.disposables.Disposable;
 import java.lang.reflect.Type;
@@ -48,7 +49,7 @@ public abstract class DefaultObserver<T> extends BaseObserver<T> {
                     Type type = new TypeToken<BaseResponse<Object>>() {
                     }.getType();
 
-                    BaseResponse baseResponse = new Gson().fromJson(responseBody.string(), type);
+                    BaseResponse baseResponse = GsonUtil.getGson().fromJson(responseBody.string(), type);
                     onNext(baseResponse);
                 }
             }

--- a/mvvmsmart/src/main/java/com/wzq/mvvmsmart/utils/constant/NetConstants.kt
+++ b/mvvmsmart/src/main/java/com/wzq/mvvmsmart/utils/constant/NetConstants.kt
@@ -1,0 +1,30 @@
+package com.wzq.mvvmsmart.utils.constant
+
+/**
+ * 网络相关常量,标识符
+ * Created by hloong on 2020/06/30.
+ */
+interface NetConstants {
+    companion object {
+
+        /**
+         * ------------------------Net 网络请求-----------------------------
+         */
+        const val AUTH = "Authorization"//token
+        const val TOKEN = "accessToken"//
+        const val DEVICE_NAME = "deviceName"//
+        const val VERSION_CODE = "versionCode"//
+        const val ICCID = "iccid"//
+        const val TRACE_ID = "traceId"
+        const val APP_VERSION = "appVersion"
+        const val MAC = "mac"
+        const val DEVICE_NUMBER = "deviceNumber"
+        /**
+         * ------------------------Net 格式-----------------------------
+         */
+        const val APPLICATION_JSON = "application/json; charset=utf-8"
+        const val APPLICATION_FORM = "application/x-www-form-urlencoded; charset=utf-8"
+        const val MULTIPART_FORM_DATA = "multipart/form-data;charset=utf-8"
+
+    }
+}


### PR DESCRIPTION
我在用这个框架，然后看到代码只有按照打包的方式配置的baseUrl，所以我在引入了一个针对单个请求动态设置baseurl的库
https://github.com/JessYanCoding/RetrofitUrlManager

因为我项目里的接口baseurl都是通过配置文件下发的，每个模块的baseurl不一样，用的比较急所以还没时间细看源码，不过知道是通过拦截固定header来替换baseUrl的，然后我把HttpCommonInterceptor 这个类的打印参数改了下，需要知道原来的请求url和实际响应的url

最后我增加了BooleanTypeAdapter和StringTypeAdapter，这个因为之前提过的，顺便加了